### PR TITLE
Improve grid scaling

### DIFF
--- a/startpage/index.html
+++ b/startpage/index.html
@@ -45,7 +45,9 @@
   </div>
 </div>
 
-  <div class="table" id="matrix"></div>
+  <div id="matrix-container">
+    <div class="table" id="matrix"></div>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/startpage/script.js
+++ b/startpage/script.js
@@ -1,5 +1,8 @@
 const COLS = 6; // Number of columns
 const ROWS = 5; // Number of rows
+const CELL_SIZE = 120; // Must match CSS .table-cell width/height
+const SPACING = 30;    // Must match CSS .table border-spacing
+const SIDEBAR_WIDTH = 300; // Sidebar width defined in CSS
 
 window.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('matrix');
@@ -77,7 +80,21 @@ window.addEventListener('DOMContentLoaded', async () => {
   // Set initial focus
   const initial = document.getElementById('initial-focus');
   if (initial) initial.focus();
+
+  // scale the matrix after it has been built
+  scaleMatrix();
 });
+
+function scaleMatrix() {
+  const matrixWidth = COLS * CELL_SIZE + SPACING * (COLS + 1);
+  const matrixHeight = ROWS * CELL_SIZE + SPACING * (ROWS + 1);
+  const availableWidth = window.innerWidth - SIDEBAR_WIDTH;
+  const availableHeight = window.innerHeight;
+  const scale = Math.min(availableWidth / matrixWidth, availableHeight / matrixHeight, 1);
+  document.documentElement.style.setProperty('--matrix-scale', scale);
+}
+
+window.addEventListener('resize', scaleMatrix);
 
 // Keyboard navigation
 document.addEventListener('keydown', function (e) {

--- a/startpage/style.css
+++ b/startpage/style.css
@@ -195,3 +195,22 @@ a {
   /* min-width: 400px; */
   /* max-width: 800px; */
 }
+
+/* Container for the application matrix */
+#matrix-container {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: calc(100vw - 300px); /* account for sidebar width */
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+/* Scale the matrix grid to fit the available space */
+#matrix {
+  transform-origin: top left;
+  transform: scale(var(--matrix-scale, 1));
+}


### PR DESCRIPTION
## Summary
- add container element for matrix grid
- dynamically scale grid layout to viewport
- style matrix container and scaling rules

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687c0336dfc88323919e0857cf76751f