### PR TITLE
Add validation for matrix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Each entry in the JSON array is an object with four properties:
 -   `vpn` (optional, link only): Set to `"on"` or `"off"` to require a specific VPN
     state before opening the link.
 
+The grid layout is fixed at 6 columns by 4 rows (24 cells). The `matrix.json`
+file must therefore contain exactly 24 entries. Any entry that is missing
+required fields is replaced with an empty placeholder when the application
+loads.
+
 #### Type: `link`
 
 A `link` type opens the specified URL in a new, fullscreen Microsoft Edge kiosk window. This is ideal for web-based streaming services.


### PR DESCRIPTION
## Summary
- enforce 6x4 matrix size with `validateMatrixConfig`
- replace invalid or missing entries with blank placeholders
- document fixed grid size and validation behavior in README

## Testing
- `npm install ajv@^8.12.0` *(fails: 403 Forbidden)*
- `node -e "require('./main.js');"` *(fails: Cannot find module 'electron')*

------
https://chatgpt.com/codex/tasks/task_e_687ccc7378788323bca14104400f7635