### PR TITLE
Fix dialog response handling

### DIFF
--- a/dialog-preload.js
+++ b/dialog-preload.js
@@ -2,5 +2,5 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('dialogAPI', {
   onDialogOptions: (callback) => ipcRenderer.on('dialog-options', (event, ...args) => callback(...args)),
-  sendResponse: (response) => ipcRenderer.send('dialog-response', response),
+  sendResponse: (id, response) => ipcRenderer.send(`dialog-response-${id}`, response),
 });

--- a/main.js
+++ b/main.js
@@ -220,7 +220,7 @@ async function getCurrentGateway() {
 // Helper: Determine VPN status
 async function getVPNStatus() {
   const gw = await getCurrentGateway();
-  console.log('Detected gateway:', gw); // <-- Add this line
+  console.log('Detected gateway:', gw);
   if (gw === '192.168.8.1') return 'on';
   if (gw === '192.168.0.1') return 'off';
   return 'unknown';
@@ -422,6 +422,7 @@ app.on('window-all-closed', () => {
 
 async function showCustomDialog(options) {
   return new Promise((resolve) => {
+    const dialogId = `dialog-${Date.now()}-${Math.random()}`;
     const modal = new BrowserWindow({
       parent: mainWindow,
       modal: true,
@@ -434,8 +435,8 @@ async function showCustomDialog(options) {
       frame: false,
       alwaysOnTop: true,
       resizable: true,
-      transparent: true, // <-- add this
-      backgroundColor: '#00000000', // <-- add this
+      transparent: true,
+      backgroundColor: '#00000000',
       webPreferences: {
         preload: path.join(__dirname, 'dialog-preload.js'),
         contextIsolation: true,
@@ -444,9 +445,9 @@ async function showCustomDialog(options) {
     });
     modal.loadFile(path.join(__dirname, 'startpage', 'dialog.html'));
     modal.webContents.once('did-finish-load', () => {
-      modal.webContents.send('dialog-options', options);
+      modal.webContents.send('dialog-options', { ...options, id: dialogId });
     });
-    ipcMain.once('dialog-response', (event, response) => {
+    ipcMain.once(`dialog-response-${dialogId}`, (event, response) => {
       resolve(response);
       modal.close();
     });

--- a/startpage/dialog.html
+++ b/startpage/dialog.html
@@ -51,6 +51,7 @@
   </div>
   <script>
     window.dialogAPI.onDialogOptions((opts) => {
+      const dlgId = opts.id;
       document.getElementById('dialog-title').textContent = opts.title || '';
       document.getElementById('dialog-message').textContent = opts.message || '';
 
@@ -62,7 +63,7 @@
         const okBtn = document.createElement('button');
         okBtn.id = 'ok-btn';
         okBtn.textContent = opts.okText;
-        okBtn.onclick = () => window.dialogAPI.sendResponse('ok');
+        okBtn.onclick = () => window.dialogAPI.sendResponse(dlgId, 'ok');
         btns.appendChild(okBtn);
         okBtn.focus();
       }
@@ -71,13 +72,13 @@
         const okBtn = document.createElement('button');
         okBtn.id = 'ok-btn';
         okBtn.textContent = opts.okText;
-        okBtn.onclick = () => window.dialogAPI.sendResponse('ok');
+        okBtn.onclick = () => window.dialogAPI.sendResponse(dlgId, 'ok');
         btns.appendChild(okBtn);
 
         const cancelBtn = document.createElement('button');
         cancelBtn.id = 'cancel-btn';
         cancelBtn.textContent = opts.cancelText;
-        cancelBtn.onclick = () => window.dialogAPI.sendResponse('cancel');
+        cancelBtn.onclick = () => window.dialogAPI.sendResponse(dlgId, 'cancel');
         btns.appendChild(cancelBtn);
 
         okBtn.focus();


### PR DESCRIPTION
## Summary
- make `showCustomDialog` use unique response channels
- update dialog preload and html to send the channel id back
- remove leftover inline comments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d50b11fbc83239f37b65f4f4c2512